### PR TITLE
Adjust to work with spatial data frames

### DIFF
--- a/R/lookin.R
+++ b/R/lookin.R
@@ -120,8 +120,7 @@ lookin.pairlist <- function(x, what, object.name, ...) {
 }
 
 lookin.matrix <- function(x, what, object.name, ...) {
-    if(class(x) != 'matrix')
-        stop("Object must be a matrix")
+    stopifnot("Object must be a matrix"=inherits(x, "matrix"))
     structure(
     c(setNames(.in_values(x, what, ...), "values"),
       setNames(.in_comment(x, what, ...), "comment"),

--- a/R/lookin.R
+++ b/R/lookin.R
@@ -76,12 +76,12 @@ lookin.factor <- function(x, what, object.name, ...) {
 
 lookin.data.frame <- function(x, what, object.name, ...) {
     stopifnot("Object must be a data.frame"=inherits(x, "data.frame"))
-    structure(list(attributes = .in_attributes(x, what, 
-                                   if(missing(object.name)) deparse(substitute(x)) else object.name, ...),
+    if(missing(object.name)) object.name <- deparse(substitute(x)) else object.name
+    structure(list(attributes = .in_attributes(x, what, ...),
                    comment = .in_comment(x, what, ...),
-                   variables = lapply(x, lookin, what = what, ...)), 
+                   variables = mapply(lookin, x, what = what, object.name=paste0(object.name, '$', colnames(x)) ...)), 
               class = "lookin.data.frame",
-              object = if(missing(object.name)) deparse(substitute(x)) else object.name,
+              object = object.name,
               what = what)
 }
 

--- a/R/lookin.R
+++ b/R/lookin.R
@@ -75,8 +75,7 @@ lookin.factor <- function(x, what, object.name, ...) {
 }
 
 lookin.data.frame <- function(x, what, object.name, ...) {
-    if(class(x) != 'data.frame')
-        stop("Object must be a data.frame")
+    stopifnot("Object must be a data.frame"=inherits(x, "data.frame"))
     structure(list(attributes = .in_attributes(x, what, 
                                    if(missing(object.name)) deparse(substitute(x)) else object.name, ...),
                    comment = .in_comment(x, what, ...),

--- a/R/lookin.R
+++ b/R/lookin.R
@@ -79,7 +79,7 @@ lookin.data.frame <- function(x, what, object.name, ...) {
     if(missing(object.name)) object.name <- deparse(substitute(x)) else object.name
     structure(list(attributes = .in_attributes(x, what, ...),
                    comment = .in_comment(x, what, ...),
-                   variables = mapply(lookin, x, what = what, object.name=paste0(object.name, '$', colnames(x)) ...)), 
+                   variables = mapply(lookin, x, what = what, object.name=paste0(object.name, '$', colnames(x)), ...)), 
               class = "lookin.data.frame",
               object = object.name,
               what = what)


### PR DESCRIPTION
Two modifications:

* Adjusts manual class checks to use inherits, now works with spatial data structures
* Manually sets object name for recursive call on lookin.data.frame

Output now looks like this on US census 2020 / Alaska with shapes and column comments

```
> lookin(akcounty20, "Hispanic")
[1] Matches found for 'Hispanic' in 'akcounty20':
[1] Matches found for 'Hispanic' in comment(akcounty20$P0020002):
Hispanic or Latino 
                 1 
[1] Matches found for 'Hispanic' in comment(akcounty20$P0020003):
Not Hispanic or Latino 
                     1 
[1] Matches found for 'Hispanic' in comment(akcounty20$P0040002):
Hispanic or latino 
                 1
```